### PR TITLE
feat: validate Telegram init data

### DIFF
--- a/lib/validateInitData.js
+++ b/lib/validateInitData.js
@@ -1,26 +1,47 @@
-
 import crypto from 'crypto';
-import querystring from 'querystring';
+
+/**
+ * Validate the X-Telegram-Init-Data header as described in
+ * https://core.telegram.org/bots/webapps#validating-data-received-via-the-web-app
+ */
 export function validateInitData(initData, botToken, maxAgeSeconds = 86400) {
   try {
     if (!initData || !botToken) return { ok: false, error: 'NO_DATA' };
-    const parsed = querystring.parse(initData);
+
+    const params = new URLSearchParams(initData);
+    const parsed = Object.create(null);
+    for (const [k, v] of params) parsed[k] = v;
+
     const receivedHash = parsed.hash;
     if (!receivedHash) return { ok: false, error: 'NO_HASH' };
     delete parsed.hash;
-    const pairs = Object.keys(parsed)
-      .map((k) => [k, Array.isArray(parsed[k]) ? parsed[k][parsed[k].length-1] : parsed[k]])
-      .sort(([a],[b]) => a.localeCompare(b))
-      .map(([k,v]) => `${k}=${v}`);
-    const dataCheckString = pairs.join('\n');
-    const secretKey = crypto.createHmac('sha256', 'WebAppData').update(botToken).digest();
-    const computedHash = crypto.createHmac('sha256', secretKey).update(dataCheckString).digest('hex');
-    if (computedHash !== receivedHash) return { ok: false, error: 'HASH_MISMATCH' };
+
+    const dataCheckString = Object.keys(parsed)
+      .sort()
+      .map((k) => `${k}=${parsed[k]}`)
+      .join('\n');
+
+    const secretKey = crypto
+      .createHmac('sha256', 'WebAppData')
+      .update(botToken)
+      .digest();
+    const computedHash = crypto
+      .createHmac('sha256', secretKey)
+      .update(dataCheckString)
+      .digest();
+    if (computedHash.length !== Buffer.from(receivedHash, 'hex').length) {
+      return { ok: false, error: 'HASH_MISMATCH' };
+    }
+    if (!crypto.timingSafeEqual(computedHash, Buffer.from(receivedHash, 'hex'))) {
+      return { ok: false, error: 'HASH_MISMATCH' };
+    }
+
     const authDate = Number(parsed.auth_date);
     if (Number.isFinite(authDate)) {
-      const now = Math.floor(Date.now()/1000);
+      const now = Math.floor(Date.now() / 1000);
       if (now - authDate > maxAgeSeconds) return { ok: false, error: 'EXPIRED' };
     }
+
     return { ok: true, data: parsed };
   } catch {
     return { ok: false, error: 'VALIDATION_ERROR' };

--- a/server.js
+++ b/server.js
@@ -49,15 +49,16 @@ const ADMIN_IDS = new Set(String(process.env.ADMIN_TG_IDS || '')
   .filter(Boolean));
 
 function parseInitData(req){
+  if (req.tgInit) return req.tgInit;
   const init = req.get('X-Telegram-Init-Data') || '';
   const token = process.env.BOT_TOKEN || '';
   const res = validateInitData(init, token);
-  if (!res.ok || !res.data.user) return { error: 'INVALID_SIGNATURE' };
+  if (!res.ok || !res.data.user) return req.tgInit = { error: 'INVALID_SIGNATURE' };
   try {
     const user = JSON.parse(res.data.user);
-    return { user };
+    return req.tgInit = { user };
   } catch {
-    return { error: 'INVALID_USER' };
+    return req.tgInit = { error: 'INVALID_USER' };
   }
 }
 


### PR DESCRIPTION
## Summary
- validate X-Telegram-Init-Data signatures using BOT_TOKEN
- deny access with 401 when signature is invalid

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68adab6b0a948329bc2328a96c4341ed